### PR TITLE
Split base wiki code from warframe wiki specific code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ run:
 linters:
   enable:
   - errcheck
-  - gofmt
   - goimports
   - gosec
   - gocritic

--- a/internal/mwmod/request.go
+++ b/internal/mwmod/request.go
@@ -1,0 +1,75 @@
+package mwmod
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/obowersa/wfwiki/internal/ratelimit"
+)
+
+type datasource interface {
+	Get(string) ([]byte, error)
+}
+
+type defaultds struct {
+	Client *http.Client
+}
+
+func (d defaultds) Get(s string) ([]byte, error) {
+	res, err := d.Client.Get(s)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, err
+}
+
+//WFWiki encapsulates the transport client and the ratelimit handler
+type Wiki struct {
+	Client  datasource
+	Handler ratelimit.Handler
+}
+
+//NewWiki returns a Wiki struct. This initialises our http client and ratelimit handler
+func NewWiki() *Wiki {
+	d := defaultds{&http.Client{}}
+	return &Wiki{d, *ratelimit.NewHandler()}
+}
+
+//Request uses an input which represents an endpoint for the underlying datasource in order to request data
+func (w Wiki) Request(s string) ([]byte, error) {
+	r := request{&w, s}
+
+	res, err := w.Handler.Get(&r)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := JSONToString(res)
+	if err != nil {
+		fmt.Printf("%s", err)
+	}
+
+	return []byte(data), nil
+}
+
+type request struct {
+	wiki *Wiki
+	url  string
+}
+
+func (r request) Call() ([]byte, error) {
+	res, err := r.wiki.Client.Get(r.url)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/internal/mwmod/request_test.go
+++ b/internal/mwmod/request_test.go
@@ -1,0 +1,34 @@
+package mwmod
+
+import "testing"
+
+type testDatasource struct{}
+
+func (d testDatasource) Get(s string) ([]byte, error) {
+	return []byte(s), nil
+}
+
+func TestRequest_Call(t *testing.T) {
+	var ds = []struct {
+		name  string
+		value string
+		err   error
+	}{
+		{"base_test", "test", nil},
+	}
+
+	for _, tt := range ds {
+		t.Run(tt.name, func(t *testing.T) {
+			var w Wiki
+
+			w.Client = testDatasource{}
+			r := request{&w, tt.value}
+			got, err := r.Call()
+			if err != nil {
+				t.Errorf("test: %s returned an error: %s", tt.name, err)
+			} else if string(got) != tt.value {
+				t.Errorf("test: %s returned unexpected result. Got: %s, expected: %s", tt.name, got, tt.value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In order to have better code segregation and allow for more reuability the code which handles base wiki requests has been split from the code which handles the warframe wiki details.

Longer term the basic approach for querying the wiki should stay largely static, where as the warframe layer will need to be updated for new tables and table structures. Additionally, this should allow for layering additional fandom wikis